### PR TITLE
Update run-addon.yml to increase timeout to max for large sets of documents 

### DIFF
--- a/.github/workflows/run-addon.yml
+++ b/.github/workflows/run-addon.yml
@@ -6,4 +6,4 @@ jobs:
   Run-Add-On:
     uses: MuckRock/documentcloud-addon-workflows/.github/workflows/run-addon.yml@v1
     with:
-      timeout: 30
+      timeout: 360


### PR DESCRIPTION
The New Yorker and APM just emailed, they will be transferring 100s of thousands of documents over to another account for ownership. This will likely require multiple runs of the AddOn on sets of 25k or so. 