### PR TITLE
Passes documents as a full set instead of relying on pagination

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ class MoveAccount(AddOn):
             raise ValueError
 
         # fetch 25 documents at a time, and bulk edit them in one call
-        documents = self.client.documents.search(self.query, per_page=BULK_LIMIT)
+        documents = self.get_documents()
         count = 0
         data = {"user": self.data["new_user_id"]}
         if new_org_id:


### PR DESCRIPTION
Move Account Add-On has been experiencing issues which I've documented here:  
https://pad.riseup.net/p/MoveAccountFailure-keep
It seems to boil down to the reliance on querying for the next 25 documents. I think this should fix the issues outlined. The timeout issue has been fixed by bumping the timeout in .constants as mentioned via Slack message